### PR TITLE
Proposal: Require space after "!"

### DIFF
--- a/coding-styles/base.js
+++ b/coding-styles/base.js
@@ -334,7 +334,10 @@ module.exports = {
     // after/before nonwords unary operators.
     'space-unary-ops': [1, {
       words: true,
-      nonwords: false
+      nonwords: false,
+      overrides: {
+        '!': true
+      }
     }],
 
     // Require or disallow a whitespace beginning a comment


### PR DESCRIPTION
This was my intention for the very beginning, unfortunately ESLint did not such configuration without forcing us to write weird code in other places.
#### Current style:

``` js
if (!true) {
  // do stuff
}
const isTrue = !true
```
#### Proposed style:

``` js
if (! true) { // <-- extra space
  // do stuff
}
const isTrue = ! true // <-- extra space
```

Violations of this rule will be automatically fixable in your codebase if this proposal is accepted, so 0 total work required on your behalf.

**Please vote with 👍 if you prefer the newly proposed coding style or 👎 if you prefer to keep the current.**
