### PR TITLE
Allow trailing comma for multiline parameters and literals

### DIFF
--- a/standard/best-practices.js
+++ b/standard/best-practices.js
@@ -15,8 +15,9 @@ module.exports = {
     'array-callback-return': 1,
 
     // This rule enforces consistent use of trailing commas in object and array literals
-    // Never allow trailing commas
-    'comma-dangle': [2, 'never'],
+    // Allow trailing commas for func parameters, array and object literals spread across
+    // multiple lines
+    'comma-dangle': [2, 'only-multiline'],
 
     // Require Function Expressions to have a Name
     // If you provide the optional name for a function expression then you will get the name of the


### PR DESCRIPTION
As trailing coma is one of [finished proposals](https://github.com/tc39/proposals/blob/master/finished-proposals.md) for ECMAScript 2017 specification, it should be allowed in coding standards.

What does it do?
It allows this:

``` javascript
function (
  param1,
  param2,
)

[
  item1,
  item2,
]

{
  prop1,
  prop2,
}
```

But it doesn't force you to use it, so this will pass to:

``` javascript
function (
  param1,
  param2
)
```

But whis will not pass:

``` javascript
function(param1, param2,)
```

Why is it good idea? You don't need to change 2 lines to add 1 param (cleaner diffs) and when you have multiple literals it is much easier to sort them aplhabeticaly 🙃

More here: https://jeffmo.github.io/es-trailing-function-commas/
