### PR TITLE
.js file extension for files with jsx

### DIFF
--- a/environments/react/recommended.js
+++ b/environments/react/recommended.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // Restrict file extensions that may contain JSX
     'react/jsx-filename-extension': [1, {
-      extensions: ['.jsx'],
+      extensions: ['.js', '.jsx'],
     }],
 
     // Detect missing key prop


### PR DESCRIPTION
Because react files in most cases contains also logic among to templating and jsx to js is only one of transformations done to these files there is no reason to restrict extension for react components to `.jsx`. 

And for fancy people who need to heave react icon next to file in their editor, I would suggest to use `.react.js` - works fine in Atom.