### PR TITLE
Explicitly specify plugins in each file if used

### DIFF
--- a/coding-styles/fixable.js
+++ b/coding-styles/fixable.js
@@ -15,6 +15,10 @@
 // then rather abandons the effort instead of fixing them.
 module.exports = {
 
+  plugins: [
+    'import',
+  ],
+
   rules: {
     // enforce line breaks after opening and before closing array brackets
     // Requires consistent usage of linebreaks for each pair of brackets. It reports an error if one

--- a/coding-styles/react.js
+++ b/coding-styles/react.js
@@ -11,6 +11,10 @@
 // These rules represent coding style targeted for React components.
 module.exports = {
 
+  plugins: [
+    'react',
+  ],
+
   rules: {
     // Validate closing bracket location in JSX
     // This rule checks all JSX multiline elements and verifies the location of the closing bracket.

--- a/coding-styles/recommended.js
+++ b/coding-styles/recommended.js
@@ -14,6 +14,10 @@ module.exports = {
 
   extends: './fixable.js',
 
+  plugins: [
+    'import',
+  ],
+
   rules: {
     // Require Camelcase
     // This rule looks for any underscores (_) located within the source code. It ignores leading

--- a/environments/react/optional.js
+++ b/environments/react/optional.js
@@ -12,6 +12,10 @@ module.exports = {
 
   extends: '../shared/optional.js',
 
+  plugins: [
+    'react',
+  ],
+
   rules: {
     // Disallow Use of Alert
     // This rule is aimed at catching debugging code that should be removed and popup UI elements

--- a/environments/react/recommended.js
+++ b/environments/react/recommended.js
@@ -25,6 +25,10 @@ module.exports = {
     },
   },
 
+  plugins: [
+    'react',
+  ],
+
   rules: {
     // Enforce JSX Quote Style
     // This rule enforces the consistent use of either double or single quotes in JSX attributes.

--- a/environments/react/v16.js
+++ b/environments/react/v16.js
@@ -14,6 +14,10 @@ module.exports = {
     './v15.js',
   ],
 
+  plugins: [
+    'react',
+  ],
+
   // Configures the react plugin to treat some rules with regard to this specific React.js version
   settings: {
     react: {

--- a/environments/shared/optional.js
+++ b/environments/shared/optional.js
@@ -12,6 +12,10 @@ const globs = require('../../globs')
 
 module.exports = {
 
+  plugins: [
+    'import',
+  ],
+
   rules: {
     // Require Consistent Returns
     // This rule is aimed at ensuring all return statements either specify a value or don't specify


### PR DESCRIPTION
Following eslint config

```
{
  "extends": [
    "@strv/javascript/coding-styles/recommended",
  ],
  "parser": "babel-eslint",
}
```

fails with warning

```
Definition for rule 'import/no-useless-path-segments' was not found 
Definition for rule 'import/order' was not found
```

because `eslint-plugin-import` is missing in plugins section therefore was never imported. Plugins used in rules definition should be always imported.