### PR TITLE
Use import/group-exports for nodejs only

### DIFF
--- a/coding-styles/recommended.js
+++ b/coding-styles/recommended.js
@@ -146,14 +146,6 @@ module.exports = {
     // The exports-last rule is currently only working on ES6 exports.
     'import/exports-last': 'warn',
 
-    // Reports when named exports are not grouped together in a single export declaration or when
-    // multiple assignments to CommonJS module.exports or exports object are present in a single
-    // file
-    // An export declaration or module.exports assignment can appear anywhere in the code. By
-    // requiring a single export declaration all your exports will remain at one place, making it
-    // easier to see what exports a module provides.
-    'import/group-exports': 'warn',
-
     // Enforces having an empty line after the last top-level import statement or require call
     'import/newline-after-import': 'warn',
   },

--- a/environments/nodejs/recommended.js
+++ b/environments/nodejs/recommended.js
@@ -61,5 +61,13 @@ module.exports = {
     'no-sync': ['warn', {
       allowAtRootLevel: true,
     }],
+
+    // Reports when named exports are not grouped together in a single export declaration or when
+    // multiple assignments to CommonJS module.exports or exports object are present in a single
+    // file
+    // An export declaration or module.exports assignment can appear anywhere in the code. By
+    // requiring a single export declaration all your exports will remain at one place, making it
+    // easier to see what exports a module provides.
+    'import/group-exports': 'warn',
   },
 }

--- a/environments/react/optional.js
+++ b/environments/react/optional.js
@@ -36,5 +36,13 @@ module.exports = {
     // accidentally injected as a text node in JSX statements.
     // Also breaks syntax highlighting in github pull requests.
     'react/no-unescaped-entities': 'warn',
+
+    // Reports when named exports are not grouped together in a single export declaration or when
+    // multiple assignments to CommonJS module.exports or exports object are present in a single
+    // file
+    // An export declaration or module.exports assignment can appear anywhere in the code. By
+    // requiring a single export declaration all your exports will remain at one place, making it
+    // easier to see what exports a module provides.
+    'import/group-exports': 'warn',
   },
 }


### PR DESCRIPTION
This commit https://github.com/strvcom/eslint-config-javascript/commit/e8452078753d043396559a10afa7227906526a54 breaks usage of `styled-components` on almost every frontend project

example:
```
import styled from 'styled-components'

export const StyledButton = styled.button`...`

export const ButtonWrapper = styled.div`...`
```

We can keep the rule in optional ruleset.