### PR TITLE
fix: distinguish between module and script only for node environment

### DIFF
--- a/environments/nodejs/recommended.js
+++ b/environments/nodejs/recommended.js
@@ -8,6 +8,8 @@
 
 'use strict'
 
+const globs = require('../../globs')
+
 module.exports = {
 
   extends: '../shared/recommended.js',
@@ -66,4 +68,22 @@ module.exports = {
       allowAtRootLevel: true,
     }],
   },
+
+  overrides: [{
+    files: globs.javascripts,
+
+    parserOptions: {
+      sourceType: 'script',
+    },
+  }, {
+    files: globs.esmodules,
+
+    parserOptions: {
+      sourceType: 'module',
+    },
+
+    env: {
+      es6: true,
+    },
+  }],
 }

--- a/environments/shared/recommended.js
+++ b/environments/shared/recommended.js
@@ -673,21 +673,5 @@ module.exports = {
       // Using process.env is encouraged in configuration files
       'no-process-env': 'off',
     },
-  }, {
-    files: globs.javascripts,
-
-    parserOptions: {
-      sourceType: 'script',
-    },
-  }, {
-    files: globs.esmodules,
-
-    parserOptions: {
-      sourceType: 'module',
-    },
-
-    env: {
-      es6: true,
-    },
   }],
 }


### PR DESCRIPTION
React environment has everything in ES6 regardless of extension, https://github.com/strvcom/eslint-config-javascript/commit/d4aaf389733e281e321e8d85f1778af28beba863 makes sense only for node.