### PR TITLE
chore: update environments readme

### DIFF
--- a/environments/nodejs/README.md
+++ b/environments/nodejs/README.md
@@ -22,6 +22,10 @@ Suitable for projects running on Node.js v8.3.
 
 > Node.js 8.3 upgraded the v8 engine to 6.0 which [brings some ECMAScript features](https://v8project.blogspot.cz/2017/06/v8-release-60.html) previously not available in Node.js . This ruleset enables those language features.
 
+### @strv/javascript/environments/nodejs/v10
+
+Suitable for projects running on Node.js v10.
+
 ### @strv/javascript/environments/nodejs/optional
 
 Use this ruleset in conjunction with any of the above version-specific rulesets. Provides additional insights into potential inconsistencies in the project.


### PR DESCRIPTION
Add the missing reference to the Node.js v10 environment.