### PR TITLE
feat: use @typescript-eslint for TypeScript rules

### DIFF
--- a/environments/typescript/README.md
+++ b/environments/typescript/README.md
@@ -11,7 +11,7 @@ These configuration files are suitable to lint TypeScript code.
 You must install an ESLint-compatible TypeScript parser and add it to your _.eslintrc.js_ file:
 
 ```sh
-npm i -D typescript-eslint-parser@latest
+npm i -D @typescript-eslint/parser@latest
 ```
 
 In addition to using this ruleset, you should also choose one base ruleset depending on your target platform:
@@ -26,7 +26,8 @@ A full configuration for a TypeScript on Node.js project:
 'use strict'
 
 module.exports = {
-  parser: 'typescript-eslint-parser',
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
 
   extends: [
     '@strv/javascript/environments/nodejs/v10',

--- a/environments/typescript/recommended.js
+++ b/environments/typescript/recommended.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   plugins: [
-    'typescript',
+    '@typescript-eslint',
   ],
 
   parserOptions: {
@@ -49,93 +49,98 @@ module.exports = {
 
     // Require that member overloads be consecutive
     // Grouping overloaded members together can improve readability of the code.
-    'typescript/adjacent-overload-signatures': 'warn',
+    '@typescript-eslint/adjacent-overload-signatures': 'warn',
 
     // Require PascalCased class and interface names
     // This rule aims to make it easy to differentiate classes from regular variables at a glance.
-    'typescript/class-name-casing': 'warn',
+    '@typescript-eslint/class-name-casing': 'warn',
 
     // Require explicit return types on functions and class methods
     // Explicit types for function return values makes it clear to any calling code what type is
     // returned. This ensures that the return value is assigned to a variable of the correct type;
     // or in the case where there is no return value, that the calling code doesn't try to use the
     // undefined value when it shouldn't.
-    'typescript/explicit-function-return-type': ['warn', {
+    '@typescript-eslint/explicit-function-return-type': ['warn', {
       allowExpressions: true,
     }],
 
     // Require explicit accessibility modifiers on class properties and methods
     // This rule aims to make code more readable and explicit about who can use which properties.
-    'typescript/explicit-member-accessibility': 'warn',
+    '@typescript-eslint/explicit-member-accessibility': 'warn',
 
     // Require that interface names be prefixed with I
     // It can be hard to differentiate between classes and interfaces. Prefixing interfaces with "I"
     // can help telling them apart at a glance.
-    'typescript/interface-name-prefix': ['warn', 'always'],
+    '@typescript-eslint/interface-name-prefix': ['warn', 'always'],
 
     // Require a specific member delimiter style for interfaces and type literals
     // This rule aims to standardise the way interface and type literal members are delimited.
-    'typescript/member-delimiter-style': ['warn', {
-      delimiter: 'none',
+    '@typescript-eslint/member-delimiter-style': ['warn', {
+      multiline: {
+        delimiter: 'none',
+      },
+      singleline: {
+        delimiter: 'comma',
+      },
     }],
 
     // Require a consistent member declaration order
     // A consistent ordering of fields, methods and constructors can make interfaces, type literals,
     // classes and class expressions easier to read, navigate and edit.
-    'typescript/member-ordering': 'warn',
+    '@typescript-eslint/member-ordering': 'warn',
 
     // Enforces the use of `as Type` assertions instead of `<Type>` assertions
     // This rule aims to standardise the use of type assertion style across the codebase.
-    'typescript/no-angle-bracket-type-assertion': 'warn',
+    '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
 
     // Disallow generic Array constructors
     // Use of the Array constructor to construct a new array is generally discouraged in favor of
     // array literal notation because of the single-argument pitfall and because the Array global
     // may be redefined.
-    'typescript/no-array-constructor': 'error',
+    '@typescript-eslint/no-array-constructor': 'error',
 
     // Disallow the declaration of empty interfaces
     // An empty interface is equivalent to its supertype. If the interface does not implement a
     // supertype, then the interface is equivalent to an empty object ({}). In both cases it can be
     // omitted.
-    'typescript/no-empty-interface': 'warn',
+    '@typescript-eslint/no-empty-interface': 'warn',
 
     // Disallows explicit type declarations for variables or parameters initialized to a number,
     // string, or boolean
     // This rule disallows explicit type declarations on parameters, variables and properties where
     // the type can be easily inferred from its value.
-    'typescript/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 'warn',
 
 
     // Disallow the use of custom TypeScript modules and namespaces
     // Custom TypeScript modules (module foo {}) and namespaces (namespace foo {}) are considered
     // outdated ways to organize TypeScript code. ES2015 module syntax is now preferred
     // (import/export).
-    'typescript/no-namespace': 'error',
+    '@typescript-eslint/no-namespace': 'error',
 
     // Disallow non-null assertions using the ! postfix operator
     // Using non-null assertions cancels the benefits of the strict null-checking mode.
-    'typescript/no-non-null-assertion': 'warn',
+    '@typescript-eslint/no-non-null-assertion': 'warn',
 
     // Disallow the use of parameter properties in class constructors
     // This rule disallows the use of parameter properties in constructors, forcing the user to
     // explicitly declare all properties in the class.
-    'typescript/no-parameter-properties': 'warn',
+    '@typescript-eslint/no-parameter-properties': 'warn',
 
     // Disallow /// <reference path="" /> comments
     // Triple-slash reference directive comments should not be used anymore. Use import instead.
-    'typescript/no-triple-slash-reference': 'error',
+    '@typescript-eslint/no-triple-slash-reference': 'error',
 
     // Prevent TypeScript-specific constructs from being erroneously flagged as unused
     // This rule only has an effect when the no-unused-vars core rule is enabled. It ensures that
     // TypeScript-specific constructs, such as implemented interfaces, are not erroneously flagged
     // as unused.
-    'typescript/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': 'error',
 
     // Disallow the use of variables before they are defined
     // This rule will warn when it encounters a reference to an identifier that has not yet been
     // declared.
-    'typescript/no-use-before-define': ['error', {
+    '@typescript-eslint/no-use-before-define': ['error', {
       functions: false,
       classes: false,
       typedefs: false,
@@ -144,18 +149,18 @@ module.exports = {
     // Disallows the use of require statements except in import statements
     // In other words, the use of forms such as var foo = require("foo") are banned. Instead use ES6
     // style imports or import foo = require("foo") imports.
-    'typescript/no-var-requires': 'error',
+    '@typescript-eslint/no-var-requires': 'error',
 
     // Require the use of the namespace keyword instead of the module keyword to declare custom
     // TypeScript modules
     // In an effort to prevent further confusion between custom TypeScript modules and the new
     // ES2015 modules, starting with TypeScript v1.5 the keyword namespace is now the preferred way
     // to declare custom TypeScript modules.
-    'typescript/prefer-namespace-keyword': 'warn',
+    '@typescript-eslint/prefer-namespace-keyword': 'warn',
 
     // Require consistent spacing around type annotations
     // This rule aims to enforce specific spacing patterns around type annotations and function
     // types in type literals.
-    'typescript/type-annotation-spacing': 'warn',
+    '@typescript-eslint/type-annotation-spacing': 'warn',
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,6 +212,41 @@
         "rimraf": "^2.5.2"
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.1.1.tgz",
+      "integrity": "sha512-7uLG6yevcS3YNMnizbZjC1xCDD2RNwqbUAPFkjz80x3NeytlIExvPR40+meGwiJ+LilgJVlqqlDMFu7PHJ6Kzw==",
+      "requires": {
+        "@typescript-eslint/parser": "1.1.1",
+        "requireindex": "^1.2.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-P6v+iYkI+ywp6MaFyAJ6NqU5W6fiAvMXWjCV63xTJbkQdtAngdjSCajlEEweqJqL4RNsgFCHBe5HbYyT6TmW4g==",
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.1.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.1.1.tgz",
+      "integrity": "sha512-rERZSjNWb4WC425daCUktfh+0fFLy4WWlnu9bESdJv5l+t0ww0yUprRUbgzehag/dGd56Me+3uyXGV2O12qxrQ==",
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -1308,7 +1343,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-      "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -1322,8 +1356,7 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "4.1.0",
@@ -1355,7 +1388,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
       }
@@ -1363,8 +1395,7 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1652,7 +1683,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1673,12 +1705,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1693,17 +1727,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1820,7 +1857,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1832,6 +1870,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1846,6 +1885,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1853,12 +1893,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1877,6 +1919,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1957,7 +2000,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1969,6 +2013,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2054,7 +2099,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2090,6 +2136,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2109,6 +2156,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2152,12 +2200,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2986,6 +3036,11 @@
       "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
       "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=",
       "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "lodash.upperfirst": {
       "version": "4.3.1",
@@ -4575,6 +4630,11 @@
           "dev": true
         }
       }
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "resolve": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "Vladimir Vanek <vladimir.vanek@strv.com>"
   ],
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.1.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-mocha": "^5.2.0",


### PR DESCRIPTION
Since eslint/typescript-eslint-parser is deprecated, let's use @typescript-eslint/parser instead.